### PR TITLE
Fix path in launch guide

### DIFF
--- a/LAUNCH_GUIDE.md
+++ b/LAUNCH_GUIDE.md
@@ -8,7 +8,7 @@ The TypeScript compilation completed successfully. Your extension is now ready t
 
 ### Method 1: Command Line (Recommended)
 ```bash
-cd "/Users/bm/Library/CloudStorage/GoogleDrive-ceo@mediaintelligence.ai/My Drive/MIZ/claude-gemini-assistant"
+cd /path/to/claude-gemini-assistant
 code .
 ```
 Then press **F5** in VS Code


### PR DESCRIPTION
## Summary
- reference the project directory generically in the quick start instructions

## Testing
- `npm test` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687fa672a7a4832d92283e953908ce1f