### PR TITLE
Add build configs for VS Code extension

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "env": {
+    "es2020": true,
+    "node": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "rules": {}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 out/
 dist/
 *.js
+!webpack.config.js
+!jest.config.js
 *.js.map
 *.d.ts
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('ts-jest').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/?(*.)+(spec|test).ts'],
+  moduleFileExtensions: ['ts', 'js', 'json', 'node']
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,33 @@
+const path = require('path');
+
+/** @type {import('webpack').Configuration} */
+module.exports = {
+  target: 'node',
+  mode: 'none',
+  entry: './src/extension.ts',
+  output: {
+    path: path.resolve(__dirname, 'out'),
+    filename: 'extension.js',
+    libraryTarget: 'commonjs2'
+  },
+  devtool: 'source-map',
+  externals: {
+    vscode: 'commonjs vscode'
+  },
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'ts-loader'
+          }
+        ]
+      }
+    ]
+  }
+};


### PR DESCRIPTION
## Summary
- add webpack config to bundle the extension
- add Jest configuration for tests
- add ESLint configuration
- adjust `.gitignore` to include the new files

## Testing
- `npm run compile` *(fails: webpack not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688786351e64832da06b9d97e95e4979