### PR TITLE
Fix project intelligence context error

### DIFF
--- a/src/core/projectIntelligenceSystem.ts
+++ b/src/core/projectIntelligenceSystem.ts
@@ -2,7 +2,7 @@
 
 import * as vscode from 'vscode';
 import { ProjectIntelligence } from './projectIntelligence';
-import { ProjectIntelligence as IProjectIntelligence } from '../types/interfaces';
+import { ProjectIntelligence as IProjectIntelligence, ProjectContext } from '../types/interfaces';
 
 /**
  * Wrapper class that adapts the ProjectIntelligence class to the expected interface
@@ -116,6 +116,10 @@ export class ProjectIntelligenceSystem {
     
     getProjectIntelligenceInstance(): ProjectIntelligence {
         return this.projectIntelligence;
+    }
+    
+    async getContextForFile(uri: vscode.Uri): Promise<ProjectContext> {
+        return this.projectIntelligence.getContextForFile(uri);
     }
     
     dispose(): void {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `getContextForFile` method to `ProjectIntelligenceSystem` to fix a TypeError.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `IntelligentTriggers` class was attempting to call `getContextForFile` on an instance of `ProjectIntelligenceSystem`, which did not expose this method. This change delegates the call to the wrapped `ProjectIntelligence` instance, resolving the `TypeError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5516be26-d377-4b38-8ebf-3b259420aa7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5516be26-d377-4b38-8ebf-3b259420aa7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>