### PR TITLE
Fix project intelligence context error

### DIFF
--- a/src/core/multiModelOrchestrator.ts
+++ b/src/core/multiModelOrchestrator.ts
@@ -242,7 +242,7 @@ export class MultiModelOrchestrator {
         
         // Add project context if available
         if (context?.includeProjectContext) {
-            const projectContext = await this.projectIntelligence.getContext();
+            const projectContext = await this.projectIntelligence.getProjectIntelligence();
             request.context = [JSON.stringify(projectContext)];
         }
         

--- a/src/core/projectIntelligenceSystem.ts
+++ b/src/core/projectIntelligenceSystem.ts
@@ -2,7 +2,7 @@
 
 import * as vscode from 'vscode';
 import { ProjectIntelligence } from './projectIntelligence';
-import { ProjectIntelligence as IProjectIntelligence } from '../types/interfaces';
+import { ProjectIntelligence as IProjectIntelligence, ProjectContext } from '../types/interfaces';
 
 /**
  * Wrapper class that adapts the ProjectIntelligence class to the expected interface
@@ -116,6 +116,10 @@ export class ProjectIntelligenceSystem {
     
     getProjectIntelligenceInstance(): ProjectIntelligence {
         return this.projectIntelligence;
+    }
+    
+    async getContextForFile(uri: vscode.Uri): Promise<ProjectContext> {
+        return await this.projectIntelligence.getContextForFile(uri);
     }
     
     dispose(): void {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `getContextForFile` to `ProjectIntelligenceSystem` and fix a related method call to resolve a `TypeError`.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `TypeError: this.projectIntelligence.getContextForFile is not a function` occurred because `IntelligentTriggers` expected this method on `ProjectIntelligenceSystem`, but it was only present on the wrapped `ProjectIntelligence` instance. This PR adds the missing method to `ProjectIntelligenceSystem` by delegating the call, and also corrects a similar method call in `multiModelOrchestrator.ts`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf14e283-555e-4352-998b-7f75f9359499">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf14e283-555e-4352-998b-7f75f9359499">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>