### PR TITLE
Fix project intelligence context error

### DIFF
--- a/src/core/projectIntelligenceSystem.ts
+++ b/src/core/projectIntelligenceSystem.ts
@@ -2,7 +2,7 @@
 
 import * as vscode from 'vscode';
 import { ProjectIntelligence } from './projectIntelligence';
-import { ProjectIntelligence as IProjectIntelligence } from '../types/interfaces';
+import { ProjectIntelligence as IProjectIntelligence, ProjectContext } from '../types/interfaces';
 
 /**
  * Wrapper class that adapts the ProjectIntelligence class to the expected interface
@@ -13,6 +13,17 @@ export class ProjectIntelligenceSystem {
     
     constructor(private context: vscode.ExtensionContext) {
         this.projectIntelligence = new ProjectIntelligence(context);
+    }
+    
+    /**
+     * Returns detailed context information for the supplied file by delegating
+     * the call to the underlying ProjectIntelligence instance.  This helper
+     * makes the frequently-used getContextForFile API available directly on
+     * the ProjectIntelligenceSystem wrapper so that callers do not need to
+     * fetch the inner instance manually.
+     */
+    async getContextForFile(uri: vscode.Uri): Promise<ProjectContext> {
+        return this.projectIntelligence.getContextForFile(uri);
     }
     
     async getProjectIntelligence(forceRefresh: boolean = false): Promise<IProjectIntelligence | null> {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Expose `getContextForFile` on `ProjectIntelligenceSystem` to resolve a runtime `TypeError`.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `ProjectIntelligenceSystem` wrapper class was missing the `getContextForFile` method, leading to a `TypeError` when downstream components (like `IntelligentTriggers`) attempted to call it. This PR adds the method, delegating the call to the underlying `ProjectIntelligence` instance.

---
<a href="https://cursor.com/background-agent?bcId=bc-830ae03e-f7ab-4eb3-a2d2-c10fffadb6b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-830ae03e-f7ab-4eb3-a2d2-c10fffadb6b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>